### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ rich = ">=13.4.2,<14.0.0"
 python-dotenv = ">=1.0.0,<2.0.0"
 packaging = ">=22.0,<25.0"
 click = "8.0.4"
-pyautogen = {version = "0.2.0", python = ">=3.10,<3.11"}
+ag2 = {version = "0.2.0", python = ">=3.10,<3.11"}
 setuptools = ">=80.9.0,<81.0.0"
 docker = ">=7.1.0,<8.0.0"
 tiktoken = ">=0.9.0,<0.10.0"


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
